### PR TITLE
Impl `Hashbox` to `Matchbox` to support concatenation

### DIFF
--- a/src/slang/parse/Parser.java
+++ b/src/slang/parse/Parser.java
@@ -223,7 +223,7 @@ public class Parser {
         if (match(NOTHING, NUMBER, STRING, ATOM, TRUE, FALSE)) {
             Token lit = previous();
             Value value = LiteralParselet.valueFromToken(lit);
-            return new Pattern.Literal(new Token(lit.opType, lit.lexeme, value, lit.line, lit.col), value);
+            return new Pattern.Literal(value);
         }
         if (match(LEFT_BRACKET)) return listPattern();
         if (match(LEFT_CURLY)) return lazyPattern();

--- a/src/slang/parse/Pattern.scala
+++ b/src/slang/parse/Pattern.scala
@@ -24,7 +24,7 @@ object Pattern {
     override def toSlangString(): String = "{" + inner.toSlangString + "}"
   }
 
-  case class Literal(token: Token, value: Value) extends Pattern {
+  case class Literal(value: Value) extends Pattern {
     override def toSlangString: String = value.toSlangString
 
     override def isHashable: Boolean = true


### PR DESCRIPTION
- Implement a method to help convert hashboxes into matchboxes, being careful to also apply the partial arguments, etc.
- Check for arity-parity between hashable rows with the additional non-hashed row, if it exists. This is to make sure we don't have a situation like: 
```
let f = { 1 2 -> 2, x -> x}
f 1
``` 
which *should* evaluate to `1`, given matchbox semantics, but without these changes would actually yield a deferred hashbox, which after applying `2` would yield `2`!? 
Hashboxes should act semantically identically to Matchboxes, since they are simply a runtime optimization.
- Remove the token from `Pattern.Literal` (so we can construct it, but also since it's unused)